### PR TITLE
Include API URL in error messages

### DIFF
--- a/Sources/Networking/APIClient.swift
+++ b/Sources/Networking/APIClient.swift
@@ -23,26 +23,31 @@ final class APIClient {
             do {
                 req.httpBody = try JSONEncoder().encode(AnyEncodable(body))
             } catch {
-                throw APIError.encoding(error)
+                throw APIError.encoding(error, url)
             }
         }
         if authorized {
-            guard let token = tokenProvider() else { throw APIError.unauthorized }
+            guard let token = tokenProvider() else { throw APIError.unauthorized(url) }
             req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
         return req
     }
 
-    func decode<T: Decodable>(_ data: Data) throws -> T {
+    func decode<T: Decodable>(_ data: Data, url: URL) throws -> T {
         do { return try JSONDecoder().decode(T.self, from: data) }
-        catch { throw APIError.decoding(error) }
+        catch { throw APIError.decoding(error, url) }
     }
 
     func perform(_ req: URLRequest) async throws -> Data {
-        let (data, resp) = try await session.data(for: req)
-        guard let http = resp as? HTTPURLResponse else { throw APIError.noData }
-        guard (200..<300).contains(http.statusCode) else { throw APIError.http(http.statusCode, data) }
-        return data
+        let url = req.url ?? endpoints.baseURL
+        do {
+            let (data, resp) = try await session.data(for: req)
+            guard let http = resp as? HTTPURLResponse else { throw APIError.noData(url) }
+            guard (200..<300).contains(http.statusCode) else { throw APIError.http(http.statusCode, data, url) }
+            return data
+        } catch {
+            throw APIError.other(error.localizedDescription, url)
+        }
     }
 
     // MARK: - Auth
@@ -52,32 +57,32 @@ final class APIClient {
     func login(email: String, password: String) async throws -> AuthTokens {
         let req = try request(endpoints.login, method: "POST", body: LoginRequest(email: email, password: password))
         let data = try await perform(req)
-        return try decode(data)
+        return try decode(data, url: req.url ?? endpoints.login)
     }
 
     func register(email: String, password: String, name: String?) async throws -> AuthTokens {
         let req = try request(endpoints.register, method: "POST", body: RegisterRequest(email: email, password: password, name: name))
         let data = try await perform(req)
-        return try decode(data)
+        return try decode(data, url: req.url ?? endpoints.register)
     }
 
     func me() async throws -> UserProfile {
         let req = try request(endpoints.me, authorized: true)
         let data = try await perform(req)
-        return try decode(data)
+        return try decode(data, url: req.url ?? endpoints.me)
     }
 
     // MARK: - Elections
     func listElections() async throws -> [Election] {
         let req = try request(endpoints.elections, authorized: true)
         let data = try await perform(req)
-        return try decode(data)
+        return try decode(data, url: req.url ?? endpoints.elections)
     }
 
     func getElection(id: Int) async throws -> Election {
         let req = try request(endpoints.election(id: id), authorized: true)
         let data = try await perform(req)
-        return try decode(data)
+        return try decode(data, url: req.url ?? endpoints.election(id: id))
     }
 
     func vote(electionId: Int, itemId: Int) async throws {
@@ -92,14 +97,14 @@ final class APIClient {
         let req = try request(endpoints.elections, method: "POST",
                               body: CreateElectionRequest(name: name, description: description), authorized: true)
         let data = try await perform(req)
-        return try decode(data)
+        return try decode(data, url: req.url ?? endpoints.elections)
     }
 
     func createItem(electionId: Int, name: String, description: String?) async throws -> ElectionItem {
         let req = try request(endpoints.items(electionId: electionId), method: "POST",
                               body: CreateItemRequest(name: name, description: description), authorized: true)
         let data = try await perform(req)
-        return try decode(data)
+        return try decode(data, url: req.url ?? endpoints.items(electionId: electionId))
     }
 
     func uploadElectionImage(electionId: Int, data: Data, filename: String, mime: String) async throws {

--- a/Sources/Networking/APIError.swift
+++ b/Sources/Networking/APIError.swift
@@ -1,30 +1,39 @@
 import Foundation
 
 enum APIError: Error, LocalizedError {
-    case invalidURL
-    case http(Int, Data?)
-    case decoding(Error)
-    case encoding(Error)
-    case noData
-    case unauthorized
-    case other(String)
+    case invalidURL(URL)
+    case http(Int, Data?, URL)
+    case decoding(Error, URL)
+    case encoding(Error, URL)
+    case noData(URL)
+    case unauthorized(URL)
+    case other(String, URL)
 
     var errorDescription: String? {
         switch self {
-        case .invalidURL: return "Invalid URL"
-        case .http(let status, _): return "Server responded with status code \(status)"
-        case .decoding(let e): return "Failed to decode response: \(e.localizedDescription)"
-        case .encoding(let e): return "Failed to encode request: \(e.localizedDescription)"
-        case .noData: return "No data in response"
-        case .unauthorized: return "You are not signed in"
-        case .other(let m): return m
+        case .invalidURL(let url):
+            return "Invalid URL \(url.absoluteString)"
+        case .http(let status, _, let url):
+            return "Server responded with status code \(status) for \(url.absoluteString)"
+        case .decoding(let e, let url):
+            return "Failed to decode response from \(url.absoluteString): \(e.localizedDescription)"
+        case .encoding(let e, let url):
+            return "Failed to encode request for \(url.absoluteString): \(e.localizedDescription)"
+        case .noData(let url):
+            return "No data in response from \(url.absoluteString)"
+        case .unauthorized(let url):
+            return "You are not signed in (while calling \(url.absoluteString))"
+        case .other(let m, let url):
+            return "\(m) (\(url.absoluteString))"
         }
     }
 
     var userMessage: String {
         switch self {
-        case .unauthorized: return "Your session expired. Please sign in again."
-        default: return self.localizedDescription
+        case .unauthorized(_):
+            return "Your session expired. Please sign in again."
+        default:
+            return self.localizedDescription
         }
     }
 }


### PR DESCRIPTION
## Summary
- attach URL context to APIError cases and messages
- propagate request URLs through APIClient for clearer diagnostics

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `make project` *(fails: xcodegen: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68be0e822d548321900a2f2ec3e7d806