### PR TITLE
Define JSONEncodable protocol for generated models

### DIFF
--- a/Generated/WotlweduAPI/Sources/JSONEncodable.swift
+++ b/Generated/WotlweduAPI/Sources/JSONEncodable.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+/// A minimal protocol that mirrors the one expected by the generated models.
+/// The models already conform to `Encodable` via `Codable`, so no additional
+/// requirements are needed here.
+public protocol JSONEncodable: Encodable {}


### PR DESCRIPTION
## Summary
- add lightweight `JSONEncodable` protocol to generated API models to fix build errors

## Testing
- `swiftc -emit-object -parse-as-library Generated/WotlweduAPI/Sources/JSONEncodable.swift Generated/WotlweduAPI/Sources/Models/*.swift`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c85d03ec83219b00481323869d6a