### PR TITLE
Add minimal API support utilities

### DIFF
--- a/Generated/WotlweduAPI/Sources/Core/APIHelper.swift
+++ b/Generated/WotlweduAPI/Sources/Core/APIHelper.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Minimal helper utilities expected by the generated API code.
+public enum APIHelper {
+    /// Maps a value to a path item by converting it to a `String`.
+    public static func mapValueToPathItem<T>(_ value: T) -> String {
+        return String(describing: value)
+    }
+
+    /// Removes any headers with `nil` values.
+    public static func rejectNilHeaders(_ headers: [String: Any?]) -> [String: Any] {
+        var result: [String: Any] = [:]
+        for (key, value) in headers {
+            if let value = value {
+                result[key] = value
+            }
+        }
+        return result
+    }
+}

--- a/Generated/WotlweduAPI/Sources/Core/AnyCodableShim.swift
+++ b/Generated/WotlweduAPI/Sources/Core/AnyCodableShim.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// A lightweight stand-in for the `AnyCodable` type used by the generated code.
+/// This is included to keep the SDK self-contained in environments where the
+/// real `AnyCodable` package is unavailable.
+public struct AnyCodable: Codable {
+    public var value: Any
+
+    public init(_ value: Any) {
+        self.value = value
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let intValue = try? container.decode(Int.self) {
+            value = intValue
+        } else if let doubleValue = try? container.decode(Double.self) {
+            value = doubleValue
+        } else if let boolValue = try? container.decode(Bool.self) {
+            value = boolValue
+        } else if let stringValue = try? container.decode(String.self) {
+            value = stringValue
+        } else if let arrayValue = try? container.decode([AnyCodable].self) {
+            value = arrayValue.map { $0.value }
+        } else if let dictValue = try? container.decode([String: AnyCodable].self) {
+            value = dictValue.mapValues { $0.value }
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "AnyCodable value cannot be decoded")
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch value {
+        case let intValue as Int:
+            try container.encode(intValue)
+        case let doubleValue as Double:
+            try container.encode(doubleValue)
+        case let boolValue as Bool:
+            try container.encode(boolValue)
+        case let stringValue as String:
+            try container.encode(stringValue)
+        case let arrayValue as [Any]:
+            let encodable = arrayValue.map { AnyCodable($0) }
+            try container.encode(encodable)
+        case let dictValue as [String: Any]:
+            let encodable = dictValue.mapValues { AnyCodable($0) }
+            try container.encode(encodable)
+        default:
+            let context = EncodingError.Context(codingPath: container.codingPath,
+                                                debugDescription: "AnyCodable value cannot be encoded")
+            throw EncodingError.invalidValue(value, context)
+        }
+    }
+}

--- a/Generated/WotlweduAPI/Sources/Core/JSONEncodingHelper.swift
+++ b/Generated/WotlweduAPI/Sources/Core/JSONEncodingHelper.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Utility for transforming `Encodable` objects into request parameters.
+public enum JSONEncodingHelper {
+    public static func encodingParameters<T: Encodable>(forEncodableObject encodable: T?) -> [String: Any]? {
+        guard let encodable = encodable else { return nil }
+        let encoder = JSONEncoder()
+        guard let data = try? encoder.encode(encodable),
+              let json = try? JSONSerialization.jsonObject(with: data),
+              let dict = json as? [String: Any] else {
+            return nil
+        }
+        return dict
+    }
+}

--- a/Generated/WotlweduAPI/Sources/Core/RequestBuilder.swift
+++ b/Generated/WotlweduAPI/Sources/Core/RequestBuilder.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// A lightweight, non-functional request builder used solely to satisfy
+/// the generated API's compile-time dependencies. Networking is left to
+/// the application integrating this SDK.
+open class RequestBuilder<T> {
+    public let method: String
+    public let URLString: String
+    public let parameters: [String: Any]?
+    public let headers: [String: Any]
+    public let requiresAuthentication: Bool
+
+    public required init(method: String,
+                         URLString: String,
+                         parameters: [String: Any]?,
+                         headers: [String: Any],
+                         requiresAuthentication: Bool) {
+        self.method = method
+        self.URLString = URLString
+        self.parameters = parameters
+        self.headers = headers
+        self.requiresAuthentication = requiresAuthentication
+    }
+
+    /// Placeholder execution method. Applications should provide their own
+    /// networking layer to actually perform the request.
+    open func execute() async throws -> Response<T> {
+        throw RequestBuilderError.executionNotSupported
+    }
+}
+
+/// Simple response wrapper matching what the generated API expects.
+public struct Response<T> {
+    public let statusCode: Int
+    public let headers: [String: String]
+    public let body: T
+
+    public init(statusCode: Int = 0, headers: [String: String] = [:], body: T) {
+        self.statusCode = statusCode
+        self.headers = headers
+        self.body = body
+    }
+}
+
+public enum RequestBuilderError: Error {
+    case executionNotSupported
+}
+
+/// Factory that returns `RequestBuilder` types.
+public class RequestBuilderFactory {
+    public init() {}
+
+    public func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {
+        return RequestBuilder<T>.self
+    }
+
+    public func getDecodableBuilder<T: Decodable>() -> RequestBuilder<T>.Type {
+        return RequestBuilder<T>.self
+    }
+}
+
+/// Namespacing object to mirror the structure used by the generator.
+public enum WotlweduAPIAPI {
+    public static var basePath: String = ""
+    public static let requestBuilderFactory = RequestBuilderFactory()
+}


### PR DESCRIPTION
## Summary
- add lightweight RequestBuilder and response types
- include helper utilities for JSON encoding and header mapping
- shim AnyCodable for environments without the dependency

## Testing
- `swiftc -typecheck Generated/WotlweduAPI/Sources/Core/*.swift Generated/WotlweduAPI/Sources/JSONEncodable.swift Generated/WotlweduAPI/Sources/APIs/DefaultAPI.swift Generated/WotlweduAPI/Sources/Models/*.swift`


------
https://chatgpt.com/codex/tasks/task_e_68c0c994f2008321a45036f4610e4a60