### PR TITLE
Replace generated backend adapter with API client

### DIFF
--- a/Sources/Adapters/GeneratedBackendAdapter.swift
+++ b/Sources/Adapters/GeneratedBackendAdapter.swift
@@ -1,102 +1,58 @@
 import Foundation
-#if canImport(WotlweduAPI)
-import WotlweduAPI
-#endif
 
+/// Stores configuration used by the backend client.
 enum GeneratedSDKConfig {
+    private static var baseURL: String = ConfigStore().baseURLString
+    private static var bearerToken: String?
+
+    /// Applies the latest base URL and bearer token. Called whenever the
+    /// session changes.
     static func apply(baseURL: String, bearerToken: String?) {
-        #if canImport(WotlweduAPI)
-        WotlweduAPI.Configuration.basePath = baseURL
-        let token = (bearerToken ?? "")
-        let keys = ["BearerAuth", "bearerAuth", "HTTPBearer", "bearer", "Authorization"]
-        if token.isEmpty {
-            for k in keys { WotlweduAPI.Configuration.apiKey[k] = nil; WotlweduAPI.Configuration.apiKeyPrefix[k] = nil }
-        } else {
-            for k in keys { WotlweduAPI.Configuration.apiKey[k] = token; WotlweduAPI.Configuration.apiKeyPrefix[k] = "Bearer" }
-        }
-        #endif
+        self.baseURL = baseURL
+        self.bearerToken = bearerToken
+    }
+
+    /// Creates an ``APIClient`` configured with the current settings.
+    fileprivate static func apiClient() -> APIClient {
+        let cfg = ConfigStore()
+        let eps = Endpoints(baseURLString: baseURL, timeout: cfg.timeout)
+        return APIClient(endpoints: eps, tokenProvider: { bearerToken })
     }
 }
 
+/// Thin wrapper around ``APIClient`` exposing the functions the rest of the
+/// app expects from the generated backend.
 enum GeneratedBackend {
-    enum NotReady: Error, LocalizedError {
-        case sdkNotGenerated
-        var errorDescription: String? { "Generated SDK not found. Run `make generate-api`." }
-    }
-    
     static func login(email: String, password: String) async throws -> AppTokens {
-        #if canImport(WotlweduAPI)
-        let body = WotlweduAPI.LoginRequest(email: email, password: password)
-        let resp = try await AuthAPI.login(body: body)
-        return AppTokens(accessToken: resp.accessToken, refreshToken: resp.refreshToken)
-        #else
-        throw NotReady.sdkNotGenerated
-        #endif
+        try await GeneratedSDKConfig.apiClient().login(email: email, password: password)
     }
-    
+
     static func register(email: String, password: String, name: String?) async throws -> AppTokens {
-        #if canImport(WotlweduAPI)
-        let body = WotlweduAPI.RegisterRequest(email: email, password: password, name: name)
-        let resp = try await AuthAPI.register(body: body)
-        return AppTokens(accessToken: resp.accessToken, refreshToken: resp.refreshToken)
-        #else
-        throw NotReady.sdkNotGenerated
-        #endif
+        try await GeneratedSDKConfig.apiClient().register(email: email, password: password, name: name)
     }
-    
+
     static func me() async throws -> AppUser {
-        #if canImport(WotlweduAPI)
-        let u = try await UsersAPI.me()
-        return AppUser(id: u.id, email: u.email, name: u.name)
-        #else
-        throw NotReady.sdkNotGenerated
-        #endif
+        try await GeneratedSDKConfig.apiClient().me()
     }
-    
+
     static func listElections() async throws -> [AppElection] {
-        #if canImport(WotlweduAPI)
-        return try await ElectionsAPI.listElections().map { g in
-            AppElection(id: g.id, name: g.name, description: g.description, items: g.items?.map { AppElectionItem(id: $0.id, name: $0.name, description: $0.description, votes: $0.votes) }, imageUrl: g.imageUrl)
-        }
-        #else
-        throw NotReady.sdkNotGenerated
-        #endif
+        try await GeneratedSDKConfig.apiClient().listElections()
     }
-    
+
     static func getElection(id: Int) async throws -> AppElection {
-        #if canImport(WotlweduAPI)
-        let g = try await ElectionsAPI.getElectionById(id: id)
-        return AppElection(id: g.id, name: g.name, description: g.description, items: g.items?.map { AppElectionItem(id: $0.id, name: $0.name, description: $0.description, votes: $0.votes) }, imageUrl: g.imageUrl)
-        #else
-        throw NotReady.sdkNotGenerated
-        #endif
+        try await GeneratedSDKConfig.apiClient().getElection(id: id)
     }
-    
+
     static func createElection(name: String, description: String?) async throws -> AppElection {
-        #if canImport(WotlweduAPI)
-        let body = WotlweduAPI.CreateElectionRequest(name: name, description: description)
-        let g = try await ElectionsAPI.createElection(body: body)
-        return AppElection(id: g.id, name: g.name, description: g.description, items: g.items?.map { AppElectionItem(id: $0.id, name: $0.name, description: $0.description, votes: $0.votes) }, imageUrl: g.imageUrl)
-        #else
-        throw NotReady.sdkNotGenerated
-        #endif
+        try await GeneratedSDKConfig.apiClient().createElection(name: name, description: description)
     }
-    
+
     static func createItem(electionId: Int, name: String, description: String?) async throws -> AppElectionItem {
-        #if canImport(WotlweduAPI)
-        let body = WotlweduAPI.CreateElectionItemRequest(name: name, description: description)
-        let it = try await ElectionsAPI.createElectionItem(electionId: electionId, body: body)
-        return AppElectionItem(id: it.id, name: it.name, description: it.description, votes: it.votes)
-        #else
-        throw NotReady.sdkNotGenerated
-        #endif
+        try await GeneratedSDKConfig.apiClient().createItem(electionId: electionId, name: name, description: description)
     }
-    
+
     static func vote(electionId: Int, itemId: Int) async throws {
-        #if canImport(WotlweduAPI)
-        _ = try await ElectionsAPI.voteItem(electionId: electionId, itemId: itemId)
-        #else
-        throw NotReady.sdkNotGenerated
-        #endif
+        try await GeneratedSDKConfig.apiClient().vote(electionId: electionId, itemId: itemId)
     }
 }
+

--- a/Sources/Networking/APIClient.swift
+++ b/Sources/Networking/APIClient.swift
@@ -69,20 +69,20 @@ final class APIClient {
         return try decode(data, url: req.url ?? endpoints.register)
     }
 
-    func me() async throws -> UserProfile {
+    func me() async throws -> AppUser {
         let req = try request(endpoints.me, authorized: true)
         let data = try await perform(req)
         return try decode(data, url: req.url ?? endpoints.me)
     }
 
     // MARK: - Elections
-    func listElections() async throws -> [Election] {
+    func listElections() async throws -> [AppElection] {
         let req = try request(endpoints.elections, authorized: true)
         let data = try await perform(req)
         return try decode(data, url: req.url ?? endpoints.elections)
     }
 
-    func getElection(id: Int) async throws -> Election {
+    func getElection(id: Int) async throws -> AppElection {
         let req = try request(endpoints.election(id: id), authorized: true)
         let data = try await perform(req)
         return try decode(data, url: req.url ?? endpoints.election(id: id))
@@ -96,14 +96,14 @@ final class APIClient {
     struct CreateElectionRequest: Codable { let name: String; let description: String? }
     struct CreateItemRequest: Codable { let name: String; let description: String? }
 
-    func createElection(name: String, description: String?) async throws -> Election {
+    func createElection(name: String, description: String?) async throws -> AppElection {
         let req = try request(endpoints.elections, method: "POST",
                               body: CreateElectionRequest(name: name, description: description), authorized: true)
         let data = try await perform(req)
         return try decode(data, url: req.url ?? endpoints.elections)
     }
 
-    func createItem(electionId: Int, name: String, description: String?) async throws -> ElectionItem {
+    func createItem(electionId: Int, name: String, description: String?) async throws -> AppElectionItem {
         let req = try request(endpoints.items(electionId: electionId), method: "POST",
                               body: CreateItemRequest(name: name, description: description), authorized: true)
         let data = try await perform(req)

--- a/Sources/Networking/BackendAdapter.swift
+++ b/Sources/Networking/BackendAdapter.swift
@@ -3,11 +3,11 @@ import Foundation
 protocol Backend {
     func login(email: String, password: String) async throws -> AppTokens
     func register(email: String, password: String, name: String?) async throws -> AppTokens
-    func me() async throws -> UserProfile
-    func listElections() async throws -> [Election]
-    func getElection(id: Int) async throws -> Election
-    func createElection(name: String, description: String?) async throws -> Election
-    func createItem(electionId: Int, name: String, description: String?) async throws -> ElectionItem
+    func me() async throws -> AppUser
+    func listElections() async throws -> [AppElection]
+    func getElection(id: Int) async throws -> AppElection
+    func createElection(name: String, description: String?) async throws -> AppElection
+    func createItem(electionId: Int, name: String, description: String?) async throws -> AppElectionItem
     func vote(electionId: Int, itemId: Int) async throws
     func uploadElectionImage(electionId: Int, data: Data, filename: String, mime: String) async throws
     func uploadItemImage(electionId: Int, itemId: Int, data: Data, filename: String, mime: String) async throws
@@ -22,11 +22,11 @@ final class ManualBackend: Backend {
     }
     func login(email: String, password: String) async throws -> AppTokens { try await api.login(email: email, password: password) }
     func register(email: String, password: String, name: String?) async throws -> AppTokens { try await api.register(email: email, password: password, name: name) }
-    func me() async throws -> UserProfile { try await api.me() }
-    func listElections() async throws -> [Election] { try await api.listElections() }
-    func getElection(id: Int) async throws -> Election { try await api.getElection(id: id) }
-    func createElection(name: String, description: String?) async throws -> Election { try await api.createElection(name: name, description: description) }
-    func createItem(electionId: Int, name: String, description: String?) async throws -> ElectionItem { try await api.createItem(electionId: electionId, name: name, description: description) }
+    func me() async throws -> AppUser { try await api.me() }
+    func listElections() async throws -> [AppElection] { try await api.listElections() }
+    func getElection(id: Int) async throws -> AppElection { try await api.getElection(id: id) }
+    func createElection(name: String, description: String?) async throws -> AppElection { try await api.createElection(name: name, description: description) }
+    func createItem(electionId: Int, name: String, description: String?) async throws -> AppElectionItem { try await api.createItem(electionId: electionId, name: name, description: description) }
     func vote(electionId: Int, itemId: Int) async throws { try await api.vote(electionId: electionId, itemId: itemId) }
     func uploadElectionImage(electionId: Int, data: Data, filename: String, mime: String) async throws { try await api.uploadElectionImage(electionId: electionId, data: data, filename: filename, mime: mime) }
     func uploadItemImage(electionId: Int, itemId: Int, data: Data, filename: String, mime: String) async throws { try await api.uploadItemImage(electionId: electionId, itemId: itemId, data: data, filename: filename, mime: mime) }


### PR DESCRIPTION
## Summary
- remove dependency on outdated WotlweduAPI types
- wrap existing APIClient for backend calls and track config
- switch networking layer to return domain models

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c0cd5061c4832183c47c18aa60901d