### PR TITLE
Assign unique bundle identifier to WotlweduAPI framework

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -11,7 +11,6 @@ settings:
     CURRENT_PROJECT_VERSION: 1
     MARKETING_VERSION: 1.0
     CODE_SIGN_STYLE: Automatic
-    INFOPLIST_FILE: Resources/Info.plist
     ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
 configs:
   Debug:
@@ -75,3 +74,5 @@ targets:
     settings:
       base:
         SKIP_INSTALL: YES
+        PRODUCT_BUNDLE_IDENTIFIER: com.example.wotlweduapi
+        GENERATE_INFOPLIST_FILE: YES


### PR DESCRIPTION
## Summary
- ensure WotlweduAPI framework uses its own bundle identifier
- let the framework generate its own Info.plist instead of inheriting the app's

## Testing
- `make project` *(fails: xcodegen: No such file or directory)*
- `curl -L https://github.com/yonaskolb/XcodeGen/releases/download/2.38.0/xcodegen-2.38.0-linux.zip -o /tmp/xcodegen.zip && unzip /tmp/xcodegen.zip -d /tmp/xcodegen && mv /tmp/xcodegen/xcodegen /usr/local/bin/xcodegen && chmod +x /usr/local/bin/xcodegen` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d0602cb083218743e548ae0c368d